### PR TITLE
Randomize parameter ordering independently per stage

### DIFF
--- a/Stage_CarbonTax/__init__.py
+++ b/Stage_CarbonTax/__init__.py
@@ -41,7 +41,11 @@ def creating_session(subsession: Subsession) -> None:
     if session_key not in subsession.session.vars:
         subsession.session.vars[session_key] = random.randint(1, C.NUM_ROUNDS)
     
-    param = get_parameter_set_for_round(subsession.session, subsession.round_number) # 抓參數組合
+    param = get_parameter_set_for_round(
+        subsession.session,
+        subsession.round_number,
+        stage_key='carbon_tax'
+    ) # 抓參數組合
 
     subsession.market_price = param['market_price']
     subsession.tax_rate = param['tax_rate']

--- a/Stage_CarbonTrading/__init__.py
+++ b/Stage_CarbonTrading/__init__.py
@@ -244,7 +244,11 @@ def creating_session(subsession: Subsession) -> None:
     if session_key not in subsession.session.vars:
         subsession.session.vars[session_key] = random.randint(1, C.NUM_ROUNDS)
 
-    param = get_parameter_set_for_round(subsession.session, subsession.round_number)
+    param = get_parameter_set_for_round(
+        subsession.session,
+        subsession.round_number,
+        stage_key='carbon_trading'
+    )
 
     subsession.market_price = param['market_price']
     subsession.tax_rate = param['tax_rate']

--- a/Stage_Control/__init__.py
+++ b/Stage_Control/__init__.py
@@ -41,7 +41,11 @@ def creating_session(subsession: Subsession) -> None:
     if session_key not in subsession.session.vars:
         subsession.session.vars[session_key] = random.randint(1, C.NUM_ROUNDS)
     
-    param = get_parameter_set_for_round(subsession.session, subsession.round_number) # 抓參數組合
+    param = get_parameter_set_for_round(
+        subsession.session,
+        subsession.round_number,
+        stage_key='control'
+    ) # 抓參數組合
 
     subsession.market_price = param['market_price']
     subsession.tax_rate = param['tax_rate']


### PR DESCRIPTION
## Summary
- update the shared parameter selection helper to store a separate randomized order for each stage
- pass explicit stage keys from the control, carbon tax, and carbon trading apps so their rounds are shuffled independently

## Testing
- python -m compileall Stage_Control Stage_CarbonTax Stage_CarbonTrading utils

------
https://chatgpt.com/codex/tasks/task_e_68c8ff5a05548330bcdf42769a8d9507