### PR TITLE
Add tax-adjusted benchmarks and round profits

### DIFF
--- a/Stage_CarbonTax/__init__.py
+++ b/Stage_CarbonTax/__init__.py
@@ -63,10 +63,13 @@ class Group(BaseGroup):
     emission = models.FloatField(initial=0)  # 記錄整個組的總排放量
     Q_soc = models.FloatField(initial=0)
     Q_mkt = models.FloatField(initial=0)
+    Q_tax = models.FloatField(initial=0)
     Pi_soc = models.FloatField(initial=0)
     Pi_mkt = models.FloatField(initial=0)
+    Pi_tax = models.FloatField(initial=0)
     E_soc = models.FloatField(initial=0)
     E_mkt = models.FloatField(initial=0)
+    E_tax = models.FloatField(initial=0)
 
 class Player(BasePlayer):
     # 企業特性
@@ -95,10 +98,13 @@ class Player(BasePlayer):
     # 基準情境與社會最適指標
     q_soc = models.IntegerField(initial=0)
     q_mkt = models.IntegerField(initial=0)
+    q_tax = models.IntegerField(initial=0)
     pi_soc = models.FloatField(initial=0)
     pi_mkt = models.FloatField(initial=0)
+    pi_tax = models.FloatField(initial=0)
     e_soc = models.FloatField(initial=0)
     e_mkt = models.FloatField(initial=0)
+    e_tax = models.FloatField(initial=0)
 
     # 回合資訊
     selected_round = models.IntegerField()

--- a/Stage_CarbonTrading/__init__.py
+++ b/Stage_CarbonTrading/__init__.py
@@ -265,10 +265,13 @@ class Group(BaseGroup):
     emission = models.FloatField(initial=0)  # 記錄整個組的總排放量
     Q_soc = models.FloatField(initial=0)
     Q_mkt = models.FloatField(initial=0)
+    Q_tax = models.FloatField(initial=0)
     Pi_soc = models.FloatField(initial=0)
     Pi_mkt = models.FloatField(initial=0)
+    Pi_tax = models.FloatField(initial=0)
     E_soc = models.FloatField(initial=0)
     E_mkt = models.FloatField(initial=0)
+    E_tax = models.FloatField(initial=0)
     buy_orders = models.LongStringField(initial='[]')
     sell_orders = models.LongStringField(initial='[]')
 
@@ -314,10 +317,13 @@ class Player(BasePlayer):
     # 基準情境與社會最適指標
     q_soc = models.IntegerField(initial=0)
     q_mkt = models.IntegerField(initial=0)
+    q_tax = models.IntegerField(initial=0)
     pi_soc = models.FloatField(initial=0)
     pi_mkt = models.FloatField(initial=0)
+    pi_tax = models.FloatField(initial=0)
     e_soc = models.FloatField(initial=0)
     e_mkt = models.FloatField(initial=0)
+    e_tax = models.FloatField(initial=0)
 
 class Introduction(Page):
     @staticmethod

--- a/Stage_Control/__init__.py
+++ b/Stage_Control/__init__.py
@@ -63,10 +63,13 @@ class Group(BaseGroup):
     emission = models.FloatField(initial=0)  # 記錄整個組的總排放量
     Q_soc = models.FloatField(initial=0)
     Q_mkt = models.FloatField(initial=0)
+    Q_tax = models.FloatField(initial=0)
     Pi_soc = models.FloatField(initial=0)
     Pi_mkt = models.FloatField(initial=0)
+    Pi_tax = models.FloatField(initial=0)
     E_soc = models.FloatField(initial=0)
     E_mkt = models.FloatField(initial=0)
+    E_tax = models.FloatField(initial=0)
 
 class Player(BasePlayer):
     # 企業特性
@@ -94,10 +97,13 @@ class Player(BasePlayer):
     # 基準情境與社會最適指標
     q_soc = models.IntegerField(initial=0)
     q_mkt = models.IntegerField(initial=0)
+    q_tax = models.IntegerField(initial=0)
     pi_soc = models.FloatField(initial=0)
     pi_mkt = models.FloatField(initial=0)
+    pi_tax = models.FloatField(initial=0)
     e_soc = models.FloatField(initial=0)
     e_mkt = models.FloatField(initial=0)
+    e_tax = models.FloatField(initial=0)
 
     # 回合資訊
     selected_round = models.IntegerField()


### PR DESCRIPTION
## Summary
- round benchmark profits to integers in shared benchmark calculations
- compute tax-adjusted benchmark quantities, emissions, and profits using new q_tax/e_tax/pi_tax metrics
- expose the new metrics on player and group models across stages and aggregate them during payoff calculations

## Testing
- python -m compileall Stage_Control Stage_CarbonTax Stage_CarbonTrading utils

------
https://chatgpt.com/codex/tasks/task_e_68ca1a2164888330938a272a125ff5fb