### PR TITLE
Adjust emission benchmarks to integers and hide debug UI

### DIFF
--- a/Stage_CarbonTax/__init__.py
+++ b/Stage_CarbonTax/__init__.py
@@ -102,9 +102,9 @@ class Player(BasePlayer):
     pi_soc = models.FloatField(initial=0)
     pi_mkt = models.FloatField(initial=0)
     pi_tax = models.FloatField(initial=0)
-    e_soc = models.FloatField(initial=0)
-    e_mkt = models.FloatField(initial=0)
-    e_tax = models.FloatField(initial=0)
+    e_soc = models.IntegerField(initial=0)
+    e_mkt = models.IntegerField(initial=0)
+    e_tax = models.IntegerField(initial=0)
 
     # 回合資訊
     selected_round = models.IntegerField()

--- a/Stage_CarbonTrading/ProductionDecision.html
+++ b/Stage_CarbonTrading/ProductionDecision.html
@@ -129,16 +129,20 @@
                 </div>
             </form>
 
+            {% if show_debug_info %}
             <!-- 調試按鈕 -->
             <div class="text-center mt-4">
                 <button type="button" class="btn btn-outline-secondary btn-sm" onclick="document.getElementById('debug-container').style.display='block';">
                     顯示調試信息
                 </button>
             </div>
+            {% endif %}
+
         </div>
     </div>
 </div>
 
+{% if show_debug_info %}
 <!-- 添加調試信息區域 -->
 <div class="container mt-3" id="debug-container" style="display: none;">
     <div class="card">
@@ -152,6 +156,7 @@
         </div>
     </div>
 </div>
+{% endif %}
 
 <script>
 // 更新生產量顯示
@@ -291,13 +296,14 @@ function updateEmissionsTable() {
     console.log('表格更新完成，行數:', emissionsTb.children.length);
 }
 
+{% if show_debug_info %}
 // 顯示調試信息
 function showDebug(message, data) {
     const debugInfo = document.getElementById('debug-info');
     const now = new Date().toLocaleTimeString();
     const msgElement = document.createElement('div');
     msgElement.innerHTML = `<strong>[${now}]</strong> ${message}`;
-    
+
     if (data) {
         const dataElement = document.createElement('pre');
         dataElement.textContent = JSON.stringify(data, null, 2);
@@ -306,7 +312,7 @@ function showDebug(message, data) {
         dataElement.style.marginTop = '4px';
         msgElement.appendChild(dataElement);
     }
-    
+
     debugInfo.appendChild(msgElement);
     document.getElementById('debug-container').style.display = 'block';
 }
@@ -314,12 +320,12 @@ function showDebug(message, data) {
 // 測試表格生成
 function testTableGeneration() {
     const table = document.getElementById('emissions-table');
-    
+
     try {
         const marginalCostCoef = parseFloat(table.getAttribute('data-marginal-cost'));
         const carbonEmission = parseFloat(table.getAttribute('data-carbon-emission'));
         const maxProd = parseInt(table.getAttribute('data-max-production'));
-        
+
         showDebug('從表格屬性讀取的值:', {
             marginalCostCoef,
             carbonEmission,
@@ -327,33 +333,34 @@ function testTableGeneration() {
             table_id: table.id,
             has_tbody: !!table.querySelector('tbody')
         });
-        
+
         // 嘗試手動生成一行
         const tbody = table.querySelector('tbody');
         const row = document.createElement('tr');
-        
+
         // 生產數量
         const cell1 = document.createElement('td');
         cell1.textContent = '測試數量';
         row.appendChild(cell1);
-        
+
         // 每單位生產成本
         const cell2 = document.createElement('td');
         cell2.textContent = '測試成本';
         row.appendChild(cell2);
-        
+
         // 碳排放
         const cell3 = document.createElement('td');
         cell3.textContent = '測試排放';
         row.appendChild(cell3);
-        
+
         tbody.appendChild(row);
-        
+
         showDebug('測試行已添加到表格中');
     } catch (error) {
         showDebug('表格生成測試錯誤:', { error: error.message, stack: error.stack });
     }
 }
+{% endif %}
 
 // 頁面加載後立即填充表格
 document.addEventListener('DOMContentLoaded', function() {

--- a/Stage_CarbonTrading/__init__.py
+++ b/Stage_CarbonTrading/__init__.py
@@ -321,9 +321,9 @@ class Player(BasePlayer):
     pi_soc = models.FloatField(initial=0)
     pi_mkt = models.FloatField(initial=0)
     pi_tax = models.FloatField(initial=0)
-    e_soc = models.FloatField(initial=0)
-    e_mkt = models.FloatField(initial=0)
-    e_tax = models.FloatField(initial=0)
+    e_soc = models.IntegerField(initial=0)
+    e_mkt = models.IntegerField(initial=0)
+    e_tax = models.IntegerField(initial=0)
 
 class Introduction(Page):
     @staticmethod
@@ -664,6 +664,7 @@ class ProductionDecision(Page):
             price_history=price_history,
             reset_cash=C.RESET_CASH_EACH_ROUND,
             disturbance_values=json.loads(player.disturbance_values),  # 新增：固定的擾動值列表
+            show_debug_info=config.test_mode,
         )
 
 #    @staticmethod

--- a/Stage_Control/__init__.py
+++ b/Stage_Control/__init__.py
@@ -101,9 +101,9 @@ class Player(BasePlayer):
     pi_soc = models.FloatField(initial=0)
     pi_mkt = models.FloatField(initial=0)
     pi_tax = models.FloatField(initial=0)
-    e_soc = models.FloatField(initial=0)
-    e_mkt = models.FloatField(initial=0)
-    e_tax = models.FloatField(initial=0)
+    e_soc = models.IntegerField(initial=0)
+    e_mkt = models.IntegerField(initial=0)
+    e_tax = models.IntegerField(initial=0)
 
     # 回合資訊
     selected_round = models.IntegerField()

--- a/utils/shared_utils.py
+++ b/utils/shared_utils.py
@@ -215,9 +215,9 @@ def calculate_player_production_benchmarks(
     profit_soc = int(round(revenue_soc - cost_soc))
     profit_tax = int(round(revenue_tax - cost_tax - tax_payment))
 
-    emissions_mkt = round(emission_per_unit * q_mkt, 2)
-    emissions_soc = round(emission_per_unit * q_soc, 2)
-    emissions_tax = round(emission_per_unit * q_tax, 2)
+    emissions_mkt = int(round(emission_per_unit * q_mkt))
+    emissions_soc = int(round(emission_per_unit * q_soc))
+    emissions_tax = int(round(emission_per_unit * q_tax))
 
     return {
         'q_soc': int(q_soc),
@@ -226,9 +226,9 @@ def calculate_player_production_benchmarks(
         'pi_soc': int(profit_soc),
         'pi_mkt': int(profit_mkt),
         'pi_tax': int(profit_tax),
-        'e_soc': float(emissions_soc),
-        'e_mkt': float(emissions_mkt),
-        'e_tax': float(emissions_tax),
+        'e_soc': emissions_soc,
+        'e_mkt': emissions_mkt,
+        'e_tax': emissions_tax,
     }
 
 def calculate_general_payoff(


### PR DESCRIPTION
## Summary
- store player benchmark emissions as integers across all treatments
- return integer emissions from the shared benchmark calculator
- limit the debug toggle and panel on the trading production decision page to test mode so production participants do not encounter them

## Testing
- `python -m compileall Stage_CarbonTrading Stage_CarbonTax Stage_Control utils`


------
https://chatgpt.com/codex/tasks/task_e_68ca1fa2a04c8330bf3a64e4c908ef44