### PR TITLE
Align carbon trading cap with tax benchmark

### DIFF
--- a/tests/test_optimal_allocation.py
+++ b/tests/test_optimal_allocation.py
@@ -24,15 +24,16 @@ class OptimalAllowanceAllocationTests(unittest.TestCase):
             DummyPlayer(market_price, marginal_cost=5, emission_per_unit=3, max_production=10),
         ]
 
+        social_cost = config.carbon_trading_social_cost_per_unit_carbon
+        tax_rate = carbon_multiplier * social_cost
+
         allocation = calculate_optimal_allowance_allocation(
             players,
             market_price=market_price,
+            tax_rate=tax_rate,
             carbon_multiplier=carbon_multiplier,
             allocation_method="equal",
         )
-
-        social_cost = config.carbon_trading_social_cost_per_unit_carbon
-        tax_rate = carbon_multiplier * social_cost
 
         expected_totals = 0
         for player, firm_details in zip(players, allocation["firm_details"]):


### PR DESCRIPTION
## Summary
- ensure the carbon trading subsession passes the configured tax rate into the optimal allowance calculator so the cap matches the tax benchmark emissions
- reuse the benchmark emissions produced by `calculate_player_production_benchmarks` when computing the cap total and update the unit test for the new signature

## Testing
- python -m pytest tests/test_optimal_allocation.py

------
https://chatgpt.com/codex/tasks/task_e_68ca3c13448c8330b95b6edf256f1cb0