### PR TITLE
Add foreign student follow-up questions to payment info stage

### DIFF
--- a/Stage_Payment_Info/BasicInfo.html
+++ b/Stage_Payment_Info/BasicInfo.html
@@ -8,11 +8,58 @@
         敬請放心作答，由衷感謝您的幫忙與支持！<br>
     </P>
 
-    {{ formfields }}
+    {{ formfield 'name' }}
+    {{ formfield 'student_id' }}
+    {{ formfield 'id_number' }}
+    {{ formfield 'address' }}
+    {{ formfield 'address_code' }}
+    {{ formfield 'is_foreign' }}
+
+    <div id="foreign-student-section" style="display: none;">
+        <hr>
+        <p>請提供以下外籍生資訊：</p>
+        {{ formfield 'arc' }}
+        {{ formfield 'passport' }}
+        {{ formfield 'nation' }}
+        {{ formfield 'stay' }}
+    </div>
     <a href="https://www.post.gov.tw/post/internet/Postal/index.jsp?ID=208" target="_blank">郵遞區號查詢</a>
     <br>
     <br>
 
     {{ next_button }}
 
+    <script>
+        (function () {
+            const foreignSection = document.getElementById('foreign-student-section');
+            const foreignRadios = document.querySelectorAll('input[name="is_foreign"]');
+            const extraInputs = foreignSection.querySelectorAll('input');
+
+            function clearExtraInputs() {
+                extraInputs.forEach((input) => {
+                    if (input.type === 'radio') {
+                        input.checked = false;
+                    } else {
+                        input.value = '';
+                    }
+                });
+            }
+
+            function toggleForeignSection() {
+                const selected = document.querySelector('input[name="is_foreign"]:checked');
+                if (selected && selected.value === '是') {
+                    foreignSection.style.display = '';
+                } else {
+                    foreignSection.style.display = 'none';
+                    clearExtraInputs();
+                }
+            }
+
+            foreignRadios.forEach((radio) => {
+                radio.addEventListener('change', toggleForeignSection);
+            });
+
+            toggleForeignSection();
+        })();
+    </script>
 {{ endblock }}

--- a/Stage_Payment_Info/__init__.py
+++ b/Stage_Payment_Info/__init__.py
@@ -25,6 +25,20 @@ class Player(BasePlayer):
     id_number = models.StringField(label="您的身份證字號")
     address = models.StringField(label="您的戶籍地址（含鄰里，需與身分證一致）")
     address_code = models.StringField(label="戶籍地址郵遞區號（3碼即可）")
+    is_foreign = models.StringField(
+        label="您是否為外籍生？",
+        choices=[('是', '是'), ('否', '否')],
+        widget=widgets.RadioSelect
+    )
+    arc = models.StringField(label="居留證號碼", blank=True)
+    passport = models.StringField(label="護照號碼", blank=True)
+    nation = models.StringField(label="國籍", blank=True)
+    stay = models.StringField(
+        label="是否在台滿 183 天",
+        choices=[('是', '是'), ('否', '否')],
+        widget=widgets.RadioSelect,
+        blank=True
+    )
 
     @staticmethod
     def calculate_payment_info(player):
@@ -89,7 +103,18 @@ class PaymentInfo(Page):
 
 class BasicInfo(Page):
     form_model = 'player'
-    form_fields = ['name', 'student_id', 'id_number', 'address', 'address_code']
+    form_fields = [
+        'name',
+        'student_id',
+        'id_number',
+        'address',
+        'address_code',
+        'is_foreign',
+        'arc',
+        'passport',
+        'nation',
+        'stay'
+    ]
 
     @staticmethod
     def error_message(player: Player, values):
@@ -109,6 +134,15 @@ class BasicInfo(Page):
             return '身份證字號格式不正確'
         if len(values['address_code']) != 3 or not values['address_code'].isnumeric():
             return '戶籍地址郵遞區號應為 3 碼數字'
+        if values['is_foreign'] == '是':
+            if not values['arc']:
+                return '請填寫居留證號碼'
+            if not values['passport']:
+                return '請填寫護照號碼'
+            if not values['nation']:
+                return '請填寫國籍'
+            if not values['stay']:
+                return '請選擇是否在台滿 183 天'
 
 class WaitForInstruction(Page):
     pass


### PR DESCRIPTION
## Summary
- add foreign student data fields to the payment info player model with conditional validation
- update the basic info page template to show the extra questions only when participants identify as foreign students

## Testing
- otree test Stage_Payment_Info *(fails: ModuleNotFoundError: No module named 'Stage_Payment_Info.tests')*


------
https://chatgpt.com/codex/tasks/task_e_68cd61e87cd883308dbdce60894f8e9b