### PR TITLE
Store real emission data and simplify payment info form

### DIFF
--- a/Stage_Payment_Info/BasicInfo.html
+++ b/Stage_Payment_Info/BasicInfo.html
@@ -12,7 +12,6 @@
     {{ formfield 'student_id' }}
     {{ formfield 'id_number' }}
     {{ formfield 'address' }}
-    {{ formfield 'address_code' }}
     {{ formfield 'is_foreign' }}
 
     <div id="foreign-student-section" style="display: none;">
@@ -23,10 +22,6 @@
         {{ formfield 'nation' }}
         {{ formfield 'stay' }}
     </div>
-    <a href="https://www.post.gov.tw/post/internet/Postal/index.jsp?ID=208" target="_blank">郵遞區號查詢</a>
-    <br>
-    <br>
-
     {{ next_button }}
 
     <script>

--- a/Stage_Payment_Info/__init__.py
+++ b/Stage_Payment_Info/__init__.py
@@ -14,7 +14,7 @@ class Subsession(BaseSubsession):
     pass
 
 class Group(BaseGroup):
-    pass
+    real_emission = models.FloatField()
 
 class Player(BasePlayer):
 
@@ -24,7 +24,6 @@ class Player(BasePlayer):
     student_id = models.StringField(label="您的學號")
     id_number = models.StringField(label="您的身份證字號")
     address = models.StringField(label="您的戶籍地址（含鄰里，需與身分證一致）")
-    address_code = models.StringField(label="戶籍地址郵遞區號（3碼即可）")
     is_foreign = models.StringField(
         label="您是否為外籍生？",
         choices=[('是', '是'), ('否', '否')],
@@ -100,6 +99,7 @@ class PaymentInfo(Page):
         info = Player.calculate_payment_info(player)
         player.payoff = cu(info['total_profit'])  # 必須是 cu() 才會統計進 payoff
         player.total_payment = info['total_payment']
+        player.group.real_emission = info['real_emission']
 
 class BasicInfo(Page):
     form_model = 'player'
@@ -108,7 +108,6 @@ class BasicInfo(Page):
         'student_id',
         'id_number',
         'address',
-        'address_code',
         'is_foreign',
         'arc',
         'passport',
@@ -132,8 +131,6 @@ class BasicInfo(Page):
             return '身份證字號第 1 碼應為英文字母'
         if not values['id_number'][1:9].isnumeric():
             return '身份證字號格式不正確'
-        if len(values['address_code']) != 3 or not values['address_code'].isnumeric():
-            return '戶籍地址郵遞區號應為 3 碼數字'
         if values['is_foreign'] == '是':
             if not values['arc']:
                 return '請填寫居留證號碼'

--- a/docs/codebook.md
+++ b/docs/codebook.md
@@ -175,7 +175,6 @@
 | `student_id` | StringField | 學號 |
 | `id_number` | StringField | 身份證字號 |
 | `address` | StringField | 戶籍地址 |
-| `address_code` | StringField | 戶籍地址郵遞區號 |
 
 #### 背景資訊
 | 變數名稱 | 資料類型 | 說明 |


### PR DESCRIPTION
## Summary
- add a `real_emission` field to the payment info group and populate it with the computed emissions value
- remove the postal code input and lookup link from the payment information form
- update the codebook documentation to reflect the removed postal code field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdf1db537883308e84f18cc6b7f66a