### PR TITLE
Implement MUDA price set rotation for practice rounds

### DIFF
--- a/configs/config.py
+++ b/configs/config.py
@@ -247,7 +247,12 @@ class ExperimentConfig:
     def muda_item_price_options(self) -> List[int]:
         """MUDA物品價格選項"""
         return self.get('stages.muda.item_price_options', [25, 30, 35, 40])
-    
+
+    @property
+    def muda_item_price_option_sets(self) -> Dict[str, List[int]]:
+        """MUDA物品價格選項組"""
+        return self.get('stages.muda.item_price_option_sets', {})
+
     @property
     def muda_item_name(self) -> str:
         """MUDA物品名稱"""

--- a/configs/experiment_config.yaml
+++ b/configs/experiment_config.yaml
@@ -130,7 +130,10 @@ stages:
     reset_cash_each_round: true
     description: "MUDA：純交易練習回合，讓受試者熟悉交易市場介面操作"
     # 碳權價格隨機抽取設定
-    item_price_options: [25, 30, 35, 40]  # 碳權價格選項
+    item_price_options: [50, 100, 150, 0, 1, 2]  # 回退使用的碳權價格選項
+    item_price_option_sets:
+      high: [50, 100, 150]
+      low: [0, 1, 2]
     
   carbon_trading:
     name_in_url: 'Stage_CarbonTrading'


### PR DESCRIPTION
## Summary
- introduce configurable MUDA price option sets and store the active set for each MUDA round
- randomize the MUDA practice schedule so that each round draws prices from the active set and assigns personal values from it
- update the experiment configuration with high and low MUDA price sets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7aa06630833087d674963cb12c21