### PR TITLE
Add school dropdown to payment info stage

### DIFF
--- a/Stage_Payment_Info/BasicInfo.html
+++ b/Stage_Payment_Info/BasicInfo.html
@@ -9,6 +9,7 @@
     </P>
 
     {{ formfield 'name' }}
+    {{ formfield 'school' }}
     {{ formfield 'student_id' }}
     {{ formfield 'id_number' }}
     {{ formfield 'address' }}

--- a/Stage_Payment_Info/__init__.py
+++ b/Stage_Payment_Info/__init__.py
@@ -21,6 +21,19 @@ class Player(BasePlayer):
     total_payment = models.IntegerField()
     # === 基本資料 ===
     name = models.StringField(label="您的名字")
+    school = models.StringField(
+        label="您的學校",
+        choices=[
+            ('國立臺灣大學', '國立臺灣大學'),
+            ('國立政治大學', '國立政治大學'),
+            ('國立臺北大學', '國立臺北大學'),
+            ('國立臺灣師範大學', '國立臺灣師範大學'),
+            ('國立臺北教育大學', '國立臺北教育大學'),
+            ('國立臺灣科技大學', '國立臺灣科技大學'),
+        ],
+        widget=widgets.Dropdown,
+        initial='國立臺灣大學',
+    )
     student_id = models.StringField(label="您的學號")
     id_number = models.StringField(label="您的身份證字號")
     address = models.StringField(label="您的戶籍地址（含鄰里，需與身分證一致）")
@@ -105,6 +118,7 @@ class BasicInfo(Page):
     form_model = 'player'
     form_fields = [
         'name',
+        'school',
         'student_id',
         'id_number',
         'address',


### PR DESCRIPTION
## Summary
- add a school field to the payment info stage with a dropdown of supported universities
- include the new school field on the basic info template with a default of National Taiwan University

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cedf2e3ad483309198183ffae42d7a