### PR TITLE
Ask for ID only from non-foreign participants

### DIFF
--- a/Stage_Payment_Info/BasicInfo.html
+++ b/Stage_Payment_Info/BasicInfo.html
@@ -9,10 +9,14 @@
     </P>
 
     {{ formfield 'name' }}
+    {{ formfield 'school' }}
     {{ formfield 'student_id' }}
-    {{ formfield 'id_number' }}
     {{ formfield 'address' }}
     {{ formfield 'is_foreign' }}
+
+    <div id="id-number-section" style="display: none;">
+        {{ formfield 'id_number' }}
+    </div>
 
     <div id="foreign-student-section" style="display: none;">
         <hr>
@@ -29,6 +33,8 @@
             const foreignSection = document.getElementById('foreign-student-section');
             const foreignRadios = document.querySelectorAll('input[name="is_foreign"]');
             const extraInputs = foreignSection.querySelectorAll('input');
+            const idSection = document.getElementById('id-number-section');
+            const idInput = idSection.querySelector('input');
 
             function clearExtraInputs() {
                 extraInputs.forEach((input) => {
@@ -44,9 +50,21 @@
                 const selected = document.querySelector('input[name="is_foreign"]:checked');
                 if (selected && selected.value === '是') {
                     foreignSection.style.display = '';
+                    idSection.style.display = 'none';
+                    if (idInput) {
+                        idInput.value = '';
+                    }
+                } else if (selected && selected.value === '否') {
+                    foreignSection.style.display = 'none';
+                    clearExtraInputs();
+                    idSection.style.display = '';
                 } else {
                     foreignSection.style.display = 'none';
                     clearExtraInputs();
+                    idSection.style.display = 'none';
+                    if (idInput) {
+                        idInput.value = '';
+                    }
                 }
             }
 

--- a/Stage_Payment_Info/__init__.py
+++ b/Stage_Payment_Info/__init__.py
@@ -21,8 +21,21 @@ class Player(BasePlayer):
     total_payment = models.IntegerField()
     # === 基本資料 ===
     name = models.StringField(label="您的名字")
+    school = models.StringField(
+        label="您的學校",
+        choices=[
+            ('國立臺灣大學', '國立臺灣大學'),
+            ('國立政治大學', '國立政治大學'),
+            ('國立臺北大學', '國立臺北大學'),
+            ('國立臺灣師範大學', '國立臺灣師範大學'),
+            ('國立臺北教育大學', '國立臺北教育大學'),
+            ('國立臺灣科技大學', '國立臺灣科技大學'),
+        ],
+        widget=widgets.Dropdown,
+        initial='國立臺灣大學',
+    )
     student_id = models.StringField(label="您的學號")
-    id_number = models.StringField(label="您的身份證字號")
+    id_number = models.StringField(label="您的身份證字號", blank=True)
     address = models.StringField(label="您的戶籍地址（含鄰里，需與身分證一致）")
     is_foreign = models.StringField(
         label="您是否為外籍生？",
@@ -105,10 +118,11 @@ class BasicInfo(Page):
     form_model = 'player'
     form_fields = [
         'name',
+        'school',
         'student_id',
-        'id_number',
         'address',
         'is_foreign',
+        'id_number',
         'arc',
         'passport',
         'nation',
@@ -117,20 +131,16 @@ class BasicInfo(Page):
 
     @staticmethod
     def error_message(player: Player, values):
-        if len(values['student_id']) != 9:
-            return '學號長度不正確'
-        if not values['student_id'][0].isalpha():
-            return '學號第 1 碼應為英文字母'
-        if not values['student_id'][1:2].isnumeric():
-            return '學號格式不正確'
-        if not values['student_id'][4:8].isnumeric():
-            return '學號格式不正確'
-        if len(values['id_number']) != 10:
-            return '身份證字號長度不正確'
-        if not values['id_number'][0].isalpha():
-            return '身份證字號第 1 碼應為英文字母'
-        if not values['id_number'][1:9].isnumeric():
-            return '身份證字號格式不正確'
+        id_number = values.get('id_number', '')
+        if values['is_foreign'] == '否':
+            if len(id_number) != 10:
+                return '身份證字號長度不正確'
+            if not id_number[0].isalpha():
+                return '身份證字號第 1 碼應為英文字母'
+            if not id_number[1:9].isnumeric():
+                return '身份證字號格式不正確'
+        else:
+            values['id_number'] = ''
         if values['is_foreign'] == '是':
             if not values['arc']:
                 return '請填寫居留證號碼'


### PR DESCRIPTION
## Summary
- add a school field to the payment info stage with a dropdown of supported universities
- include the new school field on the basic info template with a default of National Taiwan University
- only display the ID number field for participants who indicate they are not foreign students and make it optional otherwise
- remove the custom validation checks for student IDs from the basic info form

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cedf2e3ad483309198183ffae42d7a