### PR TITLE
Show ID number question only for domestic students

### DIFF
--- a/Stage_Payment_Info/BasicInfo.html
+++ b/Stage_Payment_Info/BasicInfo.html
@@ -13,7 +13,7 @@
     {{ formfield 'student_id' }}
     {{ formfield 'is_foreign' }}
 
-    <div id="id-number-section">
+    <div id="id-number-section" style="display: none;">
         {{ formfield 'id_number' }}
     </div>
 
@@ -49,7 +49,18 @@
 
             function toggleForeignSection() {
                 const selected = document.querySelector('input[name="is_foreign"]:checked');
-                if (selected && selected.value === '是') {
+
+                if (!selected) {
+                    foreignSection.style.display = 'none';
+                    clearExtraInputs();
+                    idSection.style.display = 'none';
+                    if (idInput) {
+                        idInput.value = '';
+                    }
+                    return;
+                }
+
+                if (selected.value === '是') {
                     foreignSection.style.display = '';
                     idSection.style.display = 'none';
                     if (idInput) {


### PR DESCRIPTION
## Summary
- hide the ID number field by default and only display it when the domestic option is selected
- ensure foreign-student inputs are cleared and the ID field is reset when switching selections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee8062fc08330b3bfbbcdc301c70f